### PR TITLE
v0.1.5-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ jobs:
       os: linux
       before_script: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
       script: mvn compile
-    - stage: testing on osx
+    - stage: testing
       os: osx
       before_script: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
       script: mvn test
-    - stage: testing on linux
+    - stage: testing
+      os: linux
       before_script: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
       script: mvn test
       after_success: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,7 @@ language: java
 
 jobs:
   include:
-    - stage: building on osx
-      os: osx
-      before_script: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-      script: mvn compile
-    - stage: building on linux
+    - stage: compiling
       os: linux
       before_script: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
       script: mvn compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+ - Moved `AppDirs` interface from package root to `appdirs` package
+
+### Removed
+ - `local` argument on `AppDirs::getSiteConfigDir`
+
 ## [0.1.4-prealpha] - 2019-03-16
 ### Added
  - Docstrings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
  - Moved `AppDirs` interface from package root to `appdirs` package
+ - Now all `AppDirs` instance methods return `Path` instead of `String`
  - `appAuthor` argument on `AppDirs` methods is now `String?` instead of `String`
  - Documentation related to changes
+ - Added *Recipes > Permissions* section to the documentation
 
 ### Removed
  - `local` argument on `AppDirs::getSiteConfigDir`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.5-alpha] - 2019-03-17
 ### Changed
  - Moved `AppDirs` interface from package root to `appdirs` package
  - Now all `AppDirs` instance methods return `Path` instead of `String`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
  - Moved `AppDirs` interface from package root to `appdirs` package
+ - `appAuthor` argument on `AppDirs` methods is now `String?` instead of `String`
+ - Documentation related to changes
 
 ### Removed
  - `local` argument on `AppDirs::getSiteConfigDir`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 kappdirs is another appdirs implementation written purely in Kotlin. It has
 a similar implementation of [harawata's appdirs](https://github.com/harawata/appdirs).
 
-This project is still work in progress.
+This project is on prealpha.
 
 # Installation
 

--- a/docs/appdirs.md
+++ b/docs/appdirs.md
@@ -11,11 +11,11 @@ Every `AppDirs` instance contains the methods below:
 
 Each method's signature contains the arguments below:
 
-| Name | Type |
-|------|------|
-| appName | String |
-| appVersion | String |
-| appAuthor | String |
+| Name | Type | Default |
+|------|------|---------|
+| appName | String | - |
+| appVersion | String | - |
+| appAuthor | String? | null |
 
 As an example:
 
@@ -25,12 +25,12 @@ val APP_NAME = "myApp"
 val APP_VERSION = "0.1.0"
 val APP_AUTHOR = "myName" // or the organization name
 
-val userDataDir: String = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
-val userConfigDir: String = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
-val userCacheDir: String = appDirs.getUserCacheDir(APP_NAME, APP_VERSION, APP_AUTHOR)
-val userLogDir: String = appDirs.getUserLogDir(APP_NAME, APP_VERSION, APP_AUTHOR)
-val siteDataDir: String = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
-val siteConfigDir: String = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userDataDir: Path = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userConfigDir: Path = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userCacheDir: Path = appDirs.getUserCacheDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userLogDir: Path = appDirs.getUserLogDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val siteDataDir: Path = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val siteConfigDir: Path = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
 ```
 
 Apart from the arguments above, `getUserDataDir` and `getUserConfigDir` methods
@@ -39,8 +39,8 @@ default. As an example:
 
 ```kotlin
 // roaming examples
-val userDataDir: String = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR, true)
-val userConfigDir: String = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR, true)
+val userDataDir: Path = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR, true)
+val userConfigDir: Path = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR, true)
 ```
 
  > <h4>Note</h4>
@@ -49,13 +49,12 @@ val userConfigDir: String = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_
  > To get more information about `roaming`, check out [this part](windows-system.md#what-is-roaming)
  > of Windows section of the documentation.
 
-Also, `getSiteDataDir` and `getSiteConfigDir` methods (last two above) have
-one extra argument called `local`, which is`false` by default. As an example:
+Also, `getSiteDataDir` method has one extra argument called `local`, which
+is`false` by default. As an example:
 
 ```kotlin
-// local examples
-val siteDataDir: String = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR, true)
-val siteConfigDir: String = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR, true)
+// local example
+val siteDataDir: Path = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR, true)
 ```
 
  > <h4>Note</h4>

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,10 +20,12 @@ You can grab an instance of `AppDirs` as below:
 
 ```kotlin
 val appDirs: AppDirs = AppDirsFactory.getInstance()
-val appData: String = appDirs.getUserDataDir("myApp", "0.1.0", "myName")
+val appData: Path = appDirs.getUserDataDir("myApp", "0.1.0", "myName")
 ```
 
-This will create an `AppDirs` object based on your operating system.
+`AppDirsFactory::getInstance` will create an `AppDirs` object based on your
+operating system and then you can use one of its methods to get `Path`
+instance.
 
 Currently, the operating systems below are supported:
 

--- a/docs/osx-system.md
+++ b/docs/osx-system.md
@@ -7,24 +7,23 @@ below:
 val appDirs: AppDirs = AppDirsFactory.getInstance()
 val APP_NAME = "myApp"
 val APP_VERSION = "0.1.0"
-val APP_AUTHOR = "myName" // it does not have any effect in Mac OS X
 
-val userDataDir: String = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userDataDir: Path = appDirs.getUserDataDir(APP_NAME, APP_VERSION)
 // /Users/<username>/Library/Application Support/myApp/0.1.0
 
-val userConfigDir: String = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userConfigDir: Path = appDirs.getUserConfigDir(APP_NAME, APP_VERSION)
 // /Users/<username>/Library/Application Support/myApp/0.1.0
 
-val userCacheDir: String = appDirs.getUserCacheDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userCacheDir: Path = appDirs.getUserCacheDir(APP_NAME, APP_VERSION)
 // /Users/<username>/Library/Caches/myApp/0.1.0
 
-val userLogDir: String = appDirs.getUserLogDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userLogDir: Path = appDirs.getUserLogDir(APP_NAME, APP_VERSION)
 // /Users/<username>/Library/Logs/myApp/0.1.0
 
-val siteDataDir: String = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val siteDataDir: Path = appDirs.getSiteDataDir(APP_NAME, APP_VERSION)
 // /Library/Application Support/myApp/0.1.0
 
-val siteConfigDir: String = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val siteConfigDir: Path = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION)
 // /Library/Application Support/myApp/0.1.0
 ```
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,17 @@
+# Permissions
+
+It is considered a good practice to check the permissions before you perform an
+operation on disk. Since `AppDirs` instance's methods all return `Path` object,
+you can use `Files::is*` methods to check out for proper permissions. Consider
+the example below:
+
+```kotlin
+// considering you already have AppDirs instance named appDirs
+
+val siteDataDir: Path = appDirs.getSiteDataDir("myApp", "0.1.0")
+// /usr/share/myApp/0.1.0
+
+val canWrite: Boolean = Files.isWritable(siteDataDir)
+// false
+// which means we cannot write to this directory
+```

--- a/docs/unix-system.md
+++ b/docs/unix-system.md
@@ -26,7 +26,7 @@ val siteLocalDataDir: Path = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, local
 val siteDataDir: Path = appDirs.getSiteDataDir(APP_NAME, APP_VERSION)
 // /usr/share/myApp/0.1.0
 
-val siteConfigDir: Path = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, local = true)
+val siteConfigDir: Path = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION)
 // /etc/myApp/0.1.0
 ```
 
@@ -37,12 +37,9 @@ val siteConfigDir: Path = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, local 
  > - `roaming` argument on `getUserDataDir` and `getUserConfigDir` has no
  >   effect in Unix system.
  > - `appAuthor` argument on every method has no effect in Unix system.
- > - Unix system uses forward slashes (/) as the directory separator.
- > - Whether you provide `local` to `getSiteConfigDir` method or not, the
- >   return value will be the same. It is kept like this to be similar to
- >   [harawata's appdirs](https://github.com/harawata/appdirs).
- > - Instead of harawata's appdirs, `getSiteConfigDir` points directly under
- >   `/etc` instead of `/etc/xdg`.
+ > - Unix system uses forward slashes (/) as the directory separator
+ > - Instead of [harawata's appdirs](https://github.com/harawata/appdirs),
+ >   `getSiteConfigDir` points directly under `/etc` instead of `/etc/xdg`.
 
 # What is meant by "Unix"?
 

--- a/docs/unix-system.md
+++ b/docs/unix-system.md
@@ -7,27 +7,26 @@ directories below:
 val appDirs: AppDirs = AppDirsFactory.getInstance()
 val APP_NAME = "myApp"
 val APP_VERSION = "0.1.0"
-val APP_AUTHOR = "myName" // it does not have any effect in Unix
 
-val userDataDir: String = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userDataDir: Path = appDirs.getUserDataDir(APP_NAME, APP_VERSION)
 // /home/<username>/.local/share/myApp/0.1.0
 
-val userConfigDir: String = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userConfigDir: Path = appDirs.getUserConfigDir(APP_NAME, APP_VERSION)
 // /home/<username>/.config/myApp/0.1.0
 
-val userCacheDir: String = appDirs.getUserCacheDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userCacheDir: Path = appDirs.getUserCacheDir(APP_NAME, APP_VERSION)
 // /home/<username>/.cache/myApp/0.1.0
 
-val userLogDir: String = appDirs.getUserLogDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userLogDir: Path = appDirs.getUserLogDir(APP_NAME, APP_VERSION)
 // /home/<username>/.cache/myApp/logs/0.1.0
 
-val siteLocalDataDir: String = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR, local = true)
+val siteLocalDataDir: Path = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, local = true)
 // /usr/local/share/myApp/0.1.0
 
-val siteDataDir: String = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val siteDataDir: Path = appDirs.getSiteDataDir(APP_NAME, APP_VERSION)
 // /usr/share/myApp/0.1.0
 
-val siteConfigDir: String = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR, local = true)
+val siteConfigDir: Path = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, local = true)
 // /etc/myApp/0.1.0
 ```
 

--- a/docs/windows-system.md
+++ b/docs/windows-system.md
@@ -9,28 +9,28 @@ val APP_NAME = "myApp"
 val APP_VERSION = "0.1.0"
 val APP_AUTHOR = "myName" // or the organization name
 
-val userLocalDataDir: String = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userLocalDataDir: Path = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
 // C:\Users\<username>\AppData\Local\myName\myApp\0.1.0
 
-val userRoamingDataDir: String = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR, roaming = true)
+val userRoamingDataDir: Path = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR, roaming = true)
 // C:\Users\<username>\AppData\Roaming\myName\myApp\0.1.0
 
-val userLocalConfigDir: String = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userLocalConfigDir: Path = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
 // C:\Users\<username>\AppData\Local\myName\myApp\0.1.0
 
-val userRoamingConfigDir: String = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR, roaming = true)
+val userRoamingConfigDir: Path = appDirs.getUserConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR, roaming = true)
 // C:\Users\<username>\AppData\Roaming\myName\myApp\0.1.0
 
-val userCacheDir: String = appDirs.getUserCacheDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userCacheDir: Path = appDirs.getUserCacheDir(APP_NAME, APP_VERSION, APP_AUTHOR)
 // C:\Users\<username>\AppData\Local\myName\myApp\Cache\0.1.0
 
-val userLogDir: String = appDirs.getUserLogDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val userLogDir: Path = appDirs.getUserLogDir(APP_NAME, APP_VERSION, APP_AUTHOR)
 // C:\Users\<username>\AppData\Local\myName\myApp\Logs\0.1.0
 
-val siteDataDir: String = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val siteDataDir: Path = appDirs.getSiteDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
 // C:\ProgramData\myName\myApp\0.1.0
 
-val siteConfigDir: String = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+val siteConfigDir: Path = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, APP_AUTHOR)
 // C:\ProgramData\myName\myApp\0.1.0
 ```
 
@@ -54,6 +54,24 @@ val siteConfigDir: String = appdirs.getSiteConfigDir(APP_NAME, APP_VERSION, APP_
  > - Windows is the only system that utilizes `appAuthor` on every method.
  > - Windows system is the only system that uses backward slashes (\\) as
  >   the directory separator.
+ 
+## Note on `appAuthor`
+
+Windows is the only system that uses `appAuthor` argument. That's why, in all
+`AppDirs` instance methods' signatures, it is marked as `String?` and defaults
+to `null`.
+
+Since it is `null` by default, you do not have to pass `appAuthor`. In this
+case, `appAuthor` will not be rendered to `Path` instance. See the examples
+below and compare them:
+
+```kotlin
+val userLocalDataDirWithAppAuthor: Path = appDirs.getUserDataDir(APP_NAME, APP_VERSION, APP_AUTHOR)
+// C:\Users\<username>\AppData\Local\myName\myApp\0.1.0
+
+val userLocalDataDirWithAppAuthor: Path = appDirs.getUserDataDir(APP_NAME, APP_VERSION)
+// C:\Users\<username>\AppData\Local\myApp\0.1.0
+```
 
 # What is Roaming?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,3 +9,4 @@ nav:
   - Windows System: windows-system.md
   - Mac OS X System: osx-system.md
   - Unix System: unix-system.md
+  - Recipes: recipes.md

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.erayerdin</groupId>
     <artifactId>kappdirs</artifactId>
-    <version>0.1.5-prealpha</version>
+    <version>0.1.5-alpha</version>
     <packaging>jar</packaging>
 
     <name>kappdirs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.erayerdin</groupId>
     <artifactId>kappdirs</artifactId>
-    <version>0.1.4-prealpha</version>
+    <version>0.1.5-prealpha</version>
     <packaging>jar</packaging>
 
     <name>kappdirs</name>

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/AppDirsFactory.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/AppDirsFactory.kt
@@ -1,5 +1,6 @@
 package io.github.erayerdin.kappdirs
 
+import io.github.erayerdin.kappdirs.appdirs.AppDirs
 import io.github.erayerdin.kappdirs.appdirs.OSXAppDirs
 import io.github.erayerdin.kappdirs.appdirs.UnixAppDirs
 import io.github.erayerdin.kappdirs.appdirs.WindowsAppDirs

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/AppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/AppDirs.kt
@@ -15,7 +15,7 @@ interface AppDirs {
      * For more information, see [here](https://kappdirs.readthedocs.io/en/latest/windows-system/#what-is-roaming).
      * @return A directory containing data related to a specific user.
      */
-    fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean = false): Path
+    fun getUserDataDir(appName: String, appVersion: String, appAuthor: String? = null, roaming: Boolean = false): Path
 
     /**
      * @param appName The name of the application.
@@ -26,7 +26,7 @@ interface AppDirs {
      * For more information, see [here](https://kappdirs.readthedocs.io/en/latest/windows-system/#what-is-roaming).
      * @return A directory containing configuration data of the application related to a specific user.
      */
-    fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean = false): Path
+    fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String? = null, roaming: Boolean = false): Path
 
     /**
      * @param appName The name of the application.
@@ -35,7 +35,7 @@ interface AppDirs {
      * It does not have any effect on Mac OS X, any Unix-based systems or any Linux distributions.
      * @return A directory containing cache data of the application. It is a user-based directory.
      */
-    fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path
+    fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String? = null): Path
 
     /**
      * @param appName The name of the application.
@@ -44,7 +44,7 @@ interface AppDirs {
      * It does not have any effect on Mac OS X, any Unix-based systems or any Linux distributions.
      * @return A directory containing log files of the application. It is a user-based directory.
      */
-    fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path
+    fun getUserLogDir(appName: String, appVersion: String, appAuthor: String? = null): Path
 
     /**
      * @param appName The name of the application.
@@ -55,7 +55,7 @@ interface AppDirs {
      * Linux distributions.
      * @return A directory containing system-wide data of the application.
      */
-    fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean = false): Path
+    fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String? = null, local: Boolean = false): Path
 
     /**
      * @param appName The name of the application.
@@ -64,5 +64,5 @@ interface AppDirs {
      * It does not have any effect on Mac OS X, any Unix-based systems or any Linux distributions.
      * @return A directory containing system-wide configuration files of the application.
      */
-    fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String): Path
+    fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String? = null): Path
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/AppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/AppDirs.kt
@@ -1,4 +1,6 @@
-package io.github.erayerdin.kappdirs
+package io.github.erayerdin.kappdirs.appdirs
+
+import java.nio.file.Path
 
 /**
  * An interface for implementing application directories.
@@ -13,7 +15,7 @@ interface AppDirs {
      * For more information, see [here](https://kappdirs.readthedocs.io/en/latest/windows-system/#what-is-roaming).
      * @return A directory containing data related to a specific user.
      */
-    fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean = false): String
+    fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean = false): Path
 
     /**
      * @param appName The name of the application.
@@ -24,7 +26,7 @@ interface AppDirs {
      * For more information, see [here](https://kappdirs.readthedocs.io/en/latest/windows-system/#what-is-roaming).
      * @return A directory containing configuration data of the application related to a specific user.
      */
-    fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean = false): String
+    fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean = false): Path
 
     /**
      * @param appName The name of the application.
@@ -33,7 +35,7 @@ interface AppDirs {
      * It does not have any effect on Mac OS X, any Unix-based systems or any Linux distributions.
      * @return A directory containing cache data of the application. It is a user-based directory.
      */
-    fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): String
+    fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path
 
     /**
      * @param appName The name of the application.
@@ -42,7 +44,7 @@ interface AppDirs {
      * It does not have any effect on Mac OS X, any Unix-based systems or any Linux distributions.
      * @return A directory containing log files of the application. It is a user-based directory.
      */
-    fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): String
+    fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path
 
     /**
      * @param appName The name of the application.
@@ -53,7 +55,7 @@ interface AppDirs {
      * Linux distributions.
      * @return A directory containing system-wide data of the application.
      */
-    fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean = false): String
+    fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean = false): Path
 
     /**
      * @param appName The name of the application.
@@ -63,5 +65,5 @@ interface AppDirs {
      * @param local This does not have any effect on this method.
      * @return A directory containing system-wide configuration files of the application.
      */
-    fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean = false): String
+    fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean = false): Path
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/AppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/AppDirs.kt
@@ -62,8 +62,7 @@ interface AppDirs {
      * @param appVersion The version of the application.
      * @param appAuthor The author of the application. You can also use your organization's name.
      * It does not have any effect on Mac OS X, any Unix-based systems or any Linux distributions.
-     * @param local This does not have any effect on this method.
      * @return A directory containing system-wide configuration files of the application.
      */
-    fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean = false): Path
+    fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String): Path
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirs.kt
@@ -1,49 +1,42 @@
 package io.github.erayerdin.kappdirs.appdirs
 
+import java.nio.file.Path
 import java.nio.file.Paths
 
 internal class OSXAppDirs: AppDirs {
-    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): String {
-        val path = Paths.get(
+    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+        return Paths.get(
             HOME_DIR,
             arrayOf("Library", "Application Support", appName, appVersion).joinToString(SEPARATOR)
         )
-
-        return path.toString()
     }
 
-    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): String {
+    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
         return getUserDataDir(appName, appVersion, appAuthor, roaming)
     }
 
-    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): String {
-        val path = Paths.get(
+    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path {
+        return Paths.get(
             HOME_DIR,
             arrayOf("Library", "Caches", appName, appVersion).joinToString(SEPARATOR)
         )
-
-        return path.toString()
     }
 
-    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): String {
-        val path = Paths.get(
+    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path {
+        return Paths.get(
             HOME_DIR,
             arrayOf("Library", "Logs", appName, appVersion).joinToString(SEPARATOR)
         )
-
-        return path.toString()
     }
 
-    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): String {
-        val path = Paths.get(
+    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
+        return Paths.get(
             "/",
             arrayOf("Library", "Application Support", appName, appVersion).joinToString(SEPARATOR)
         )
-
-        return path.toString()
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): String {
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
         return getSiteDataDir(appName, appVersion, appAuthor, local)
     }
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirs.kt
@@ -36,7 +36,7 @@ internal class OSXAppDirs: AppDirs {
         )
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
-        return getSiteDataDir(appName, appVersion, appAuthor, local)
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String): Path {
+        return getSiteDataDir(appName, appVersion, appAuthor)
     }
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirs.kt
@@ -4,39 +4,39 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 internal class OSXAppDirs: AppDirs {
-    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String?, roaming: Boolean): Path {
         return Paths.get(
             HOME_DIR,
             arrayOf("Library", "Application Support", appName, appVersion).joinToString(SEPARATOR)
         )
     }
 
-    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String?, roaming: Boolean): Path {
         return getUserDataDir(appName, appVersion, appAuthor, roaming)
     }
 
-    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path {
+    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String?): Path {
         return Paths.get(
             HOME_DIR,
             arrayOf("Library", "Caches", appName, appVersion).joinToString(SEPARATOR)
         )
     }
 
-    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path {
+    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String?): Path {
         return Paths.get(
             HOME_DIR,
             arrayOf("Library", "Logs", appName, appVersion).joinToString(SEPARATOR)
         )
     }
 
-    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
+    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String?, local: Boolean): Path {
         return Paths.get(
             "/",
             arrayOf("Library", "Application Support", appName, appVersion).joinToString(SEPARATOR)
         )
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String): Path {
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String?): Path {
         return getSiteDataDir(appName, appVersion, appAuthor)
     }
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirs.kt
@@ -1,6 +1,5 @@
 package io.github.erayerdin.kappdirs.appdirs
 
-import io.github.erayerdin.kappdirs.AppDirs
 import java.nio.file.Paths
 
 internal class OSXAppDirs: AppDirs {

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirs.kt
@@ -1,6 +1,5 @@
 package io.github.erayerdin.kappdirs.appdirs
 
-import io.github.erayerdin.kappdirs.AppDirs
 import java.nio.file.Paths
 
 internal class UnixAppDirs: AppDirs {

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirs.kt
@@ -42,7 +42,7 @@ internal class UnixAppDirs: AppDirs {
         return Paths.get("/", directories.joinToString(SEPARATOR))
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String): Path {
         return Paths.get("/", arrayOf("etc", appName, appVersion).joinToString(SEPARATOR))
     }
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirs.kt
@@ -4,35 +4,35 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 internal class UnixAppDirs: AppDirs {
-    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String?, roaming: Boolean): Path {
         return Paths.get(
             HOME_DIR,
             arrayOf(".local", "share", appName, appVersion).joinToString(SEPARATOR)
         )
     }
 
-    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String?, roaming: Boolean): Path {
         return Paths.get(
             HOME_DIR,
             arrayOf(".config", appName, appVersion).joinToString(SEPARATOR)
         )
     }
 
-    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path {
+    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String?): Path {
         return Paths.get(
             HOME_DIR,
             arrayOf(".cache", appName, appVersion).joinToString(SEPARATOR)
         )
     }
 
-    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path {
+    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String?): Path {
         return Paths.get(
             HOME_DIR,
             arrayOf(".cache", appName, "logs", appVersion).joinToString(SEPARATOR)
         )
     }
 
-    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
+    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String?, local: Boolean): Path {
         val directories: Array<String> = if (local) {
             arrayOf("usr", "local", "share", appName, appVersion)
         } else {
@@ -42,7 +42,7 @@ internal class UnixAppDirs: AppDirs {
         return Paths.get("/", directories.joinToString(SEPARATOR))
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String): Path {
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String?): Path {
         return Paths.get("/", arrayOf("etc", appName, appVersion).joinToString(SEPARATOR))
     }
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirs.kt
@@ -1,57 +1,48 @@
 package io.github.erayerdin.kappdirs.appdirs
 
+import java.nio.file.Path
 import java.nio.file.Paths
 
 internal class UnixAppDirs: AppDirs {
-    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): String {
-        val path = Paths.get(
+    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+        return Paths.get(
             HOME_DIR,
             arrayOf(".local", "share", appName, appVersion).joinToString(SEPARATOR)
         )
-
-        return path.toString()
     }
 
-    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): String {
-        val path = Paths.get(
+    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+        return Paths.get(
             HOME_DIR,
             arrayOf(".config", appName, appVersion).joinToString(SEPARATOR)
         )
-
-        return path.toString()
     }
 
-    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): String {
-        val path = Paths.get(
+    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path {
+        return Paths.get(
             HOME_DIR,
             arrayOf(".cache", appName, appVersion).joinToString(SEPARATOR)
         )
-
-        return path.toString()
     }
 
-    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): String {
-        val path = Paths.get(
+    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path {
+        return Paths.get(
             HOME_DIR,
             arrayOf(".cache", appName, "logs", appVersion).joinToString(SEPARATOR)
         )
-
-        return path.toString()
     }
 
-    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): String {
+    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
         val directories: Array<String> = if (local) {
             arrayOf("usr", "local", "share", appName, appVersion)
         } else {
             arrayOf("usr", "share", appName, appVersion)
         }
 
-        val path = Paths.get("/", directories.joinToString(SEPARATOR))
-        return path.toString()
+        return Paths.get("/", directories.joinToString(SEPARATOR))
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): String {
-        val path = Paths.get("/", arrayOf("etc", appName, appVersion).joinToString(SEPARATOR))
-        return path.toString()
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
+        return Paths.get("/", arrayOf("etc", appName, appVersion).joinToString(SEPARATOR))
     }
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirs.kt
@@ -1,43 +1,35 @@
 package io.github.erayerdin.kappdirs.appdirs
 
-import io.github.erayerdin.kappdirs.AppDirs
 import java.nio.file.Path
 import java.nio.file.Paths
 
 internal class WindowsAppDirs: AppDirs {
-    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): String {
-        val appData: String
-        val path: Path
-
-        if (roaming)
-            appData = APPDATA
+    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+        val appData: String = if (roaming)
+            APPDATA
         else
-            appData = LOCALAPPDATA
+            LOCALAPPDATA
 
-        path = Paths.get(appData, appAuthor, appName, appVersion)
-        return path.toString()
+        return Paths.get(appData, appAuthor, appName, appVersion)
     }
 
-    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): String {
+    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
         return getUserDataDir(appName, appVersion, appAuthor, roaming)
     }
 
-    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): String {
-        val path = Paths.get(LOCALAPPDATA, appAuthor, appName, "Cache", appVersion)
-        return path.toString()
+    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path {
+        return Paths.get(LOCALAPPDATA, appAuthor, appName, "Cache", appVersion)
     }
 
-    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): String {
-        val path = Paths.get(LOCALAPPDATA, appAuthor, appName, "Logs", appVersion)
-        return path.toString()
+    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path {
+        return Paths.get(LOCALAPPDATA, appAuthor, appName, "Logs", appVersion)
     }
 
-    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): String {
-        val path = Paths.get(PROGRAMDATA, appAuthor, appName, appVersion)
-        return path.toString()
+    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
+        return Paths.get(PROGRAMDATA, appAuthor, appName, appVersion)
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): String {
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
         return getSiteDataDir(appName, appVersion, appAuthor, local)
     }
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirs.kt
@@ -4,32 +4,44 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 internal class WindowsAppDirs: AppDirs {
-    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String?, roaming: Boolean): Path {
         val appData: String = if (roaming)
             APPDATA
         else
             LOCALAPPDATA
 
-        return Paths.get(appData, appAuthor, appName, appVersion)
+        return when (appAuthor) {
+            null -> Paths.get(appData, appName, appVersion)
+            else -> Paths.get(appData, appAuthor, appName, appVersion)
+        }
     }
 
-    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path {
+    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String?, roaming: Boolean): Path {
         return getUserDataDir(appName, appVersion, appAuthor, roaming)
     }
 
-    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path {
-        return Paths.get(LOCALAPPDATA, appAuthor, appName, "Cache", appVersion)
+    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String?): Path {
+        return when (appAuthor) {
+            null -> Paths.get(LOCALAPPDATA, appName, "Cache", appVersion)
+            else -> Paths.get(LOCALAPPDATA, appAuthor, appName, "Cache", appVersion)
+        }
     }
 
-    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path {
-        return Paths.get(LOCALAPPDATA, appAuthor, appName, "Logs", appVersion)
+    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String?): Path {
+        return when (appAuthor) {
+            null -> Paths.get(LOCALAPPDATA, appName, "Logs", appVersion)
+            else -> Paths.get(LOCALAPPDATA, appAuthor, appName, "Logs", appVersion)
+        }
     }
 
-    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
-        return Paths.get(PROGRAMDATA, appAuthor, appName, appVersion)
+    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String?, local: Boolean): Path {
+        return when (appAuthor) {
+            null -> Paths.get(PROGRAMDATA, appName, appVersion)
+            else -> Paths.get(PROGRAMDATA, appAuthor, appName, appVersion)
+        }
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String): Path {
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String?): Path {
         return getSiteDataDir(appName, appVersion, appAuthor)
     }
 }

--- a/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirs.kt
+++ b/src/main/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirs.kt
@@ -29,7 +29,7 @@ internal class WindowsAppDirs: AppDirs {
         return Paths.get(PROGRAMDATA, appAuthor, appName, appVersion)
     }
 
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path {
-        return getSiteDataDir(appName, appVersion, appAuthor, local)
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String): Path {
+        return getSiteDataDir(appName, appVersion, appAuthor)
     }
 }

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsFactoryTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsFactoryTest.kt
@@ -1,5 +1,6 @@
 package io.github.erayerdin.kappdirs
 
+import io.github.erayerdin.kappdirs.appdirs.AppDirs
 import org.junit.Test
 import kotlin.test.assertSame
 

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsTest.kt
@@ -19,32 +19,32 @@ object ImplAppDirs: AppDirs {
 class AppDirsTest {
     @Test
     fun testUserDataDir() = assertEquals(
-        "a",
+        Paths.get("/a"),
         ImplAppDirs.getUserDataDir("foo", "0.1.0", "eray")
     )
     @Test
     fun testUserConfigDir() = assertEquals(
-        "b",
+        Paths.get("/b"),
         ImplAppDirs.getUserConfigDir("foo", "0.1.0", "eray")
     )
     @Test
     fun testUserCacheDir() = assertEquals(
-        "c",
+        Paths.get("/c"),
         ImplAppDirs.getUserCacheDir("foo", "0.1.0", "eray")
     )
     @Test
     fun testUserLogDir() = assertEquals(
-        "d",
+        Paths.get("/d"),
         ImplAppDirs.getUserLogDir("foo", "0.1.0", "eray")
     )
     @Test
     fun testSiteDataDir() = assertEquals(
-        "e",
+        Paths.get("/e"),
         ImplAppDirs.getSiteDataDir("foo", "0.1.0", "eray")
     )
     @Test
     fun testSiteConfigDir() = assertEquals(
-        "f",
+        Paths.get("/f"),
         ImplAppDirs.getSiteConfigDir("foo", "0.1.0", "eray")
     )
 }

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsTest.kt
@@ -7,12 +7,12 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 object ImplAppDirs: AppDirs {
-    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path = Paths.get("/a")
-    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path = Paths.get("/b")
-    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path = Paths.get("/c")
-    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path = Paths.get("/d")
-    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path = Paths.get("/e")
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path = Paths.get("/f")
+    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String?, roaming: Boolean): Path = Paths.get("/a")
+    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String?, roaming: Boolean): Path = Paths.get("/b")
+    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String?): Path = Paths.get("/c")
+    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String?): Path = Paths.get("/d")
+    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String?, local: Boolean): Path = Paths.get("/e")
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String?): Path = Paths.get("/f")
 
 }
 

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsTest.kt
@@ -1,5 +1,6 @@
 package io.github.erayerdin.kappdirs
 
+import io.github.erayerdin.kappdirs.appdirs.AppDirs
 import org.junit.Assert.*
 import org.junit.Test
 

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/AppDirsTest.kt
@@ -1,16 +1,18 @@
 package io.github.erayerdin.kappdirs
 
 import io.github.erayerdin.kappdirs.appdirs.AppDirs
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.nio.file.Path
+import java.nio.file.Paths
 
 object ImplAppDirs: AppDirs {
-    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): String = "a"
-    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): String = "b"
-    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): String = "c"
-    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): String = "d"
-    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): String = "e"
-    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): String = "f"
+    override fun getUserDataDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path = Paths.get("/a")
+    override fun getUserConfigDir(appName: String, appVersion: String, appAuthor: String, roaming: Boolean): Path = Paths.get("/b")
+    override fun getUserCacheDir(appName: String, appVersion: String, appAuthor: String): Path = Paths.get("/c")
+    override fun getUserLogDir(appName: String, appVersion: String, appAuthor: String): Path = Paths.get("/d")
+    override fun getSiteDataDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path = Paths.get("/e")
+    override fun getSiteConfigDir(appName: String, appVersion: String, appAuthor: String, local: Boolean): Path = Paths.get("/f")
 
 }
 

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/AppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/AppDirsTest.kt
@@ -1,6 +1,5 @@
-package io.github.erayerdin.kappdirs
+package io.github.erayerdin.kappdirs.appdirs
 
-import io.github.erayerdin.kappdirs.appdirs.AppDirs
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.nio.file.Path

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirsTest.kt
@@ -2,6 +2,7 @@ package io.github.erayerdin.kappdirs.appdirs
 
 import org.junit.*
 import org.junit.Assert.assertEquals
+import java.nio.file.Paths
 
 class OSXAppDirsTest {
     companion object {
@@ -30,7 +31,7 @@ class OSXAppDirsTest {
     @Test
     fun testUserDataDir() {
         assertEquals(
-            "/Users/bar/Library/Application Support/foo/0.1.0",
+            Paths.get("/Users/bar/Library/Application Support/foo/0.1.0"),
             appDirs.getUserDataDir(appName, appVersion, appAuthor)
         )
     }
@@ -43,7 +44,7 @@ class OSXAppDirsTest {
     @Test
     fun testUserCacheDir() {
         assertEquals(
-            "/Users/bar/Library/Caches/foo/0.1.0",
+            Paths.get("/Users/bar/Library/Caches/foo/0.1.0"),
             appDirs.getUserCacheDir(appName, appVersion, appAuthor)
         )
     }
@@ -51,7 +52,7 @@ class OSXAppDirsTest {
     @Test
     fun testUserLogDir() {
         assertEquals(
-            "/Users/bar/Library/Logs/foo/0.1.0",
+            Paths.get("/Users/bar/Library/Logs/foo/0.1.0"),
             appDirs.getUserLogDir(appName, appVersion, appAuthor)
         )
     }
@@ -59,7 +60,7 @@ class OSXAppDirsTest {
     @Test
     fun testSiteDataDir() {
         assertEquals(
-            "/Library/Application Support/foo/0.1.0",
+            Paths.get("/Library/Application Support/foo/0.1.0"),
             appDirs.getSiteDataDir(appName, appVersion, appAuthor)
         )
     }

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/OSXAppDirsTest.kt
@@ -1,6 +1,5 @@
 package io.github.erayerdin.kappdirs.appdirs
 
-import io.github.erayerdin.kappdirs.AppDirs
 import org.junit.*
 import org.junit.Assert.assertEquals
 

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirsTest.kt
@@ -1,6 +1,5 @@
 package io.github.erayerdin.kappdirs.appdirs
 
-import io.github.erayerdin.kappdirs.AppDirs
 import org.junit.*
 import org.junit.Assert.assertEquals
 

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirsTest.kt
@@ -7,7 +7,6 @@ import java.nio.file.Paths
 internal val originalHome = System.getProperty("user.home")
 internal val osName = System.getProperty("os.name")?.toLowerCase()
 
-internal const val appAuthor = "eray"
 internal const val appName = "foo"
 internal const val appVersion = "0.1.0"
 

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/UnixAppDirsTest.kt
@@ -2,6 +2,7 @@ package io.github.erayerdin.kappdirs.appdirs
 
 import org.junit.*
 import org.junit.Assert.assertEquals
+import java.nio.file.Paths
 
 internal val originalHome = System.getProperty("user.home")
 internal val osName = System.getProperty("os.name")?.toLowerCase()
@@ -37,7 +38,7 @@ class UnixAppDirsTest {
     @Test
     fun testUserDataDir() {
         assertEquals(
-            "/home/bar/.local/share/foo/0.1.0",
+            Paths.get("/home/bar/.local/share/foo/0.1.0"),
             appDirs.getUserDataDir(appName, appVersion, appAuthor)
         )
     }
@@ -45,7 +46,7 @@ class UnixAppDirsTest {
     @Test
     fun testUserConfigDir() {
         assertEquals(
-            "/home/bar/.config/foo/0.1.0",
+            Paths.get("/home/bar/.config/foo/0.1.0"),
             appDirs.getUserConfigDir(appName, appVersion, appAuthor)
         )
     }
@@ -53,7 +54,7 @@ class UnixAppDirsTest {
     @Test
     fun testUserCacheDir() {
         assertEquals(
-            "/home/bar/.cache/foo/0.1.0",
+            Paths.get("/home/bar/.cache/foo/0.1.0"),
             appDirs.getUserCacheDir(appName, appVersion, appAuthor)
         )
     }
@@ -61,7 +62,7 @@ class UnixAppDirsTest {
     @Test
     fun testUserLogDir() {
         assertEquals(
-            "/home/bar/.cache/foo/logs/0.1.0",
+            Paths.get("/home/bar/.cache/foo/logs/0.1.0"),
             appDirs.getUserLogDir(appName, appVersion, appAuthor)
         )
     }
@@ -69,7 +70,7 @@ class UnixAppDirsTest {
     @Test
     fun testLocalSiteDataDir() {
         assertEquals(
-            "/usr/local/share/foo/0.1.0",
+            Paths.get("/usr/local/share/foo/0.1.0"),
             appDirs.getSiteDataDir(appName, appVersion, appAuthor, true)
         )
     }
@@ -77,7 +78,7 @@ class UnixAppDirsTest {
     @Test
     fun testSiteDataDir() {
         assertEquals(
-            "/usr/share/foo/0.1.0",
+            Paths.get("/usr/share/foo/0.1.0"),
             appDirs.getSiteDataDir(appName, appVersion, appAuthor)
         )
     }
@@ -85,7 +86,7 @@ class UnixAppDirsTest {
     @Test
     fun testSiteConfigDir() {
         assertEquals(
-            "/etc/foo/0.1.0",
+            Paths.get("/etc/foo/0.1.0"),
             appDirs.getSiteConfigDir(appName, appVersion, appAuthor)
         )
     }

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 private val systemDrive = System.getenv("SystemDrive")
+internal const val appAuthor = "eray"
 
 class WindowsAppDirsTest {
     companion object {
@@ -28,10 +29,24 @@ class WindowsAppDirsTest {
     }
 
     @Test
+    fun testLocalUserDataDirWithoutAppAuthor() {
+        val dir = appDirs.getUserDataDir(appName, appVersion, null)
+        assertTrue(dir.toString().startsWith("$systemDrive\\Users\\"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Local\\foo\\0.1.0"))
+    }
+
+    @Test
     fun testRoamingUserDataDir() {
         val dir = appDirs.getUserDataDir(appName, appVersion, appAuthor, true)
         assertTrue(dir.toString().startsWith("$systemDrive\\Users\\"))
         assertTrue(dir.toString().endsWith("\\AppData\\Roaming\\eray\\foo\\0.1.0"))
+    }
+
+    @Test
+    fun testRoamingUserDataDirWithoutAppAuthor() {
+        val dir = appDirs.getUserDataDir(appName, appVersion, null, true)
+        assertTrue(dir.toString().startsWith("$systemDrive\\Users\\"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Roaming\\foo\\0.1.0"))
     }
 
     @Test
@@ -40,13 +55,25 @@ class WindowsAppDirsTest {
     }
 
     @Test
-    fun testRoamingUserConfigDir() {
-        testRoamingUserDataDir()
+    fun testLocalUserConfigDirWithoutAppAuthor() {
+        testLocalUserDataDirWithoutAppAuthor()
+    }
+
+    @Test
+    fun testRoamingUserConfigDirWithoutAppAuthor() {
+        testRoamingUserDataDirWithoutAppAuthor()
     }
 
     @Test
     fun testUserCacheDir() {
         val dir = appDirs.getUserCacheDir(appName, appVersion, appAuthor)
+        assertTrue(dir.toString().startsWith("$systemDrive\\Users"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Local\\eray\\foo\\Cache\\0.1.0"))
+    }
+
+    @Test
+    fun testUserCacheDirWithoutAuthor() {
+        val dir = appDirs.getUserCacheDir(appName, appVersion, null)
         assertTrue(dir.toString().startsWith("$systemDrive\\Users"))
         assertTrue(dir.toString().endsWith("\\AppData\\Local\\eray\\foo\\Cache\\0.1.0"))
     }
@@ -59,13 +86,31 @@ class WindowsAppDirsTest {
     }
 
     @Test
+    fun testUserLogDirWithoutAppAuthor() {
+        val dir = appDirs.getUserLogDir(appName, appVersion, null)
+        assertTrue(dir.toString().startsWith("$systemDrive\\Users"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Local\\foo\\Logs\\0.1.0"))
+    }
+
+    @Test
     fun testSiteDataDir() {
         val dir = appDirs.getSiteDataDir(appName, appVersion, appAuthor)
         assertEquals("$systemDrive\\ProgramData\\eray\\foo\\0.1.0", dir.toString())
     }
 
     @Test
+    fun testSiteDataDirWithoutAppAuthor() {
+        val dir = appDirs.getSiteDataDir(appName, appVersion, null)
+        assertEquals("$systemDrive\\ProgramData\\foo\\0.1.0", dir.toString())
+    }
+
+    @Test
     fun testSiteConfigDir() {
         testSiteDataDir()
+    }
+
+    @Test
+    fun testSiteConfigDirWithoutAppAuthor() {
+        testSiteDataDirWithoutAppAuthor()
     }
 }

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
@@ -47,15 +47,15 @@ class WindowsAppDirsTest {
     @Test
     fun testUserCacheDir() {
         val dir = appDirs.getUserCacheDir(appName, appVersion, appAuthor)
-        assertTrue(dir.startsWith("$systemDrive\\Users"))
-        assertTrue(dir.endsWith("\\AppData\\Local\\eray\\foo\\Cache\\0.1.0"))
+        assertTrue(dir.toString().startsWith("$systemDrive\\Users"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Local\\eray\\foo\\Cache\\0.1.0"))
     }
 
     @Test
     fun testUserLogDir() {
         val dir = appDirs.getUserLogDir(appName, appVersion, appAuthor)
-        assertTrue(dir.startsWith("$systemDrive\\Users"))
-        assertTrue(dir.endsWith("\\AppData\\Local\\eray\\foo\\Logs\\0.1.0"))
+        assertTrue(dir.toString().startsWith("$systemDrive\\Users"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Local\\eray\\foo\\Logs\\0.1.0"))
     }
 
     @Test

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
@@ -23,15 +23,15 @@ class WindowsAppDirsTest {
     @Test
     fun testLocalUserDataDir() {
         val dir = appDirs.getUserDataDir(appName, appVersion, appAuthor)
-        assertTrue(dir.startsWith("$systemDrive\\Users\\"))
-        assertTrue(dir.endsWith("\\AppData\\Local\\eray\\foo\\0.1.0"))
+        assertTrue(dir.toString().startsWith("$systemDrive\\Users\\"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Local\\eray\\foo\\0.1.0"))
     }
 
     @Test
     fun testRoamingUserDataDir() {
         val dir = appDirs.getUserDataDir(appName, appVersion, appAuthor, true)
-        assertTrue(dir.startsWith("$systemDrive\\Users\\"))
-        assertTrue(dir.endsWith("\\AppData\\Roaming\\eray\\foo\\0.1.0"))
+        assertTrue(dir.toString().startsWith("$systemDrive\\Users\\"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Roaming\\eray\\foo\\0.1.0"))
     }
 
     @Test

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
@@ -75,7 +75,7 @@ class WindowsAppDirsTest {
     fun testUserCacheDirWithoutAuthor() {
         val dir = appDirs.getUserCacheDir(appName, appVersion, null)
         assertTrue(dir.toString().startsWith("$systemDrive\\Users"))
-        assertTrue(dir.toString().endsWith("\\AppData\\Local\\eray\\foo\\Cache\\0.1.0"))
+        assertTrue(dir.toString().endsWith("\\AppData\\Local\\foo\\Cache\\0.1.0"))
     }
 
     @Test

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
@@ -1,6 +1,5 @@
 package io.github.erayerdin.kappdirs.appdirs
 
-import io.github.erayerdin.kappdirs.AppDirs
 import org.junit.Assert.assertTrue
 import org.junit.Assume
 import org.junit.Before

--- a/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
+++ b/src/test/kotlin/io/github/erayerdin/kappdirs/appdirs/WindowsAppDirsTest.kt
@@ -61,7 +61,7 @@ class WindowsAppDirsTest {
     @Test
     fun testSiteDataDir() {
         val dir = appDirs.getSiteDataDir(appName, appVersion, appAuthor)
-        assertEquals("$systemDrive\\ProgramData\\eray\\foo\\0.1.0", dir)
+        assertEquals("$systemDrive\\ProgramData\\eray\\foo\\0.1.0", dir.toString())
     }
 
     @Test


### PR DESCRIPTION
### Changed
 - Moved `AppDirs` interface from package root to `appdirs` package
 - Now all `AppDirs` instance methods return `Path` instead of `String`
 - `appAuthor` argument on `AppDirs` methods is now `String?` instead of `String`
 - Documentation related to changes
 - Added *Recipes > Permissions* section to the documentation

### Removed
 - `local` argument on `AppDirs::getSiteConfigDir`